### PR TITLE
Require rules to be over T when sorting

### DIFF
--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -11,7 +11,7 @@ extension Sorted<T> on Iterable<T> {
   /// will perform the final sorting procedure. Defaults to [DefaultSortingStrategy].
   /// Consider using [MergeSortingStrategy] if a stable sort is needed.
   List<T> sorted(
-    List<SortedRule> rules, {
+    List<SortedRule<T, dynamic>> rules, {
     SortingStrategy<T>? sortingStrategy,
   }) {
     sortingStrategy ??= DefaultSortingStrategy<T>();


### PR DESCRIPTION
When sorting a list the rules should be applicable to the list elements (`T`). Before the sorted extension would allow for arbitrary rules, which would crash at runtime if the types do not match.

`SortedRule` should be contravariant over `T` rather than covariant. With a bit of hacking this should be possible to enforce, but might make the API uglier.